### PR TITLE
Make `pickle5` requirement Python version dependent

### DIFF
--- a/mle_logging/utils/helpers.py
+++ b/mle_logging/utils/helpers.py
@@ -1,6 +1,5 @@
 import os
-import pickle
-import pickle5
+import sys
 from typing import Any, Union, List, Tuple
 import h5py
 import yaml
@@ -10,6 +9,12 @@ import pandas as pd
 import re
 from dotmap import DotMap
 import collections
+
+if sys.version_info < (3, 8):
+    # Load with pickle5 for python version compatibility
+    import pickle5 as pickle
+else:
+    import pickle
 
 
 def save_pkl_object(obj: Any, filename: str) -> None:
@@ -34,8 +39,7 @@ def load_pkl_object(filename: str) -> Any:
         Any: Reloaded object.
     """
     with open(filename, "rb") as input:
-        # Load with pickle5 for python version compatibility
-        obj = pickle5.load(input)
+        obj = pickle.load(input)
     return obj
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ pyyaml>=5.1
 numpy
 h5py
 dotmap
-pickle5
+pickle5; python_version < '3.8'
 rich


### PR DESCRIPTION
The `pickle5` dependency forces `python < 3.8`. If I understand it correctly, `pickle5` is only there to backport `pickle` features that were added with Python 3.8, right? I modified the dependency to only apply for Python < 3.8. With this I was able to install `mle-logging` in my Python 3.9 environment.

I also modified the only place where `pickle5` was used. Didn't test anything, I was hoping this PR would trigger some tests to make sure I didn't break anything (didn't want to install all those test dependencies locally :P).